### PR TITLE
changed request for axios, removed unnecesary packages (lodash BluebirdPromises)

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,10 +23,8 @@
   },
   "homepage": "https://github.com/99xt/azure-jwt-verify#readme",
   "dependencies": {
-    "bluebird": "^3.4.7",
     "jsonwebtoken": "^8.5.1",
-    "lodash": "^4.17.4",
-    "request": "^2.79.0",
+    "axios": "^0.23.0",
     "rsa-pem-from-mod-exp": "^0.8.4"
   }
 }


### PR DESCRIPTION
Some tidying up, 
* removed dependency bloating  (there was realy no need to include lodash just for a forEach)
* Removed bluebirdPromises and changed those for regular ES6 promises as the overhead is not justified
* changed request for axios (as request is deprecated)

TODO : 
* the rsa-pem-from-mod-exp module is kind of hacky and also not being actively maintained so we might want to consider bringing it's codebase over and making some adjustments
* We should write some tests for the module if we want to make it available for the general public